### PR TITLE
Update list of workshops and people

### DIFF
--- a/pages/people.rst
+++ b/pages/people.rst
@@ -21,7 +21,7 @@
    | Xiao Fang
    | `Jia Liu <https://liuxx479.github.io/>`_
    | Daniel Kuesters
-   | Paul La Plante
+   | `Paul La Plante <https://plaplant.github.io/>`_
    | `Emmanuel Schaan <https://eschaan.lbl.gov/>`_
    | George Stein
    | `Marius Millea <https://cosmicmar.com/>`_

--- a/pages/workshops.rst
+++ b/pages/workshops.rst
@@ -4,6 +4,7 @@
 .. tags: 
 .. description: 
 
+* `Reionization and Cosmic Dawn: Looking Forward To the Past <http://bccp.berkeley.edu/2022-reionization/index.html>`_, 2022 Mar 21-23, Berkeley, CA
 * `Spectroscopic Surveys: Are We Ready For the Future <http://bccp.berkeley.edu/2020-spectroscopic/index.html>`_, 2020 Jan 13-15, Berkeley, CA
 * Note: sadly, there will be no 2019 summer workshop in Slovenia due to conflicts with other meetings.
 * `Weak gravitational lensing 2019 <http://bccp.berkeley.edu/2019-lensing/index.html>`_, 2019 Jan 14-16, Berkeley, CA


### PR DESCRIPTION
This PR adds a link to the workshops page about the one this spring, and adds a link to my personal page on the list of people. I have already added a [branch](https://github.com/bccp/workshops/tree/2022-reionization) to the workshops repo.